### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/scannet2.py
+++ b/scannet2.py
@@ -33,7 +33,7 @@ def lstvssql(lstOut):
                 'WHERE mac="' + mac +'"' )
         cur.execute(cmd)
         rsl = cur.fetchone()
-        if (rsl == None):
+        if (rsl is None):
           # MAC is not found in db
           if (line[5] != 0):
             # & host is pingable -> new host, so add it to the DB
@@ -78,7 +78,7 @@ def lstvssql(lstOut):
           rsl = cur.fetchone()
           # example output
           # rsl <= ('00:00:00:00:00:00', '182', datetime.datetime(2015, 10, 18, 14, 45, 26), 'hostname')
-          if (rsl != None):
+          if (rsl is not None):
             line[1] = "-" + rsl[3]
             line[2] = "-" + rsl[3]
             line[3] = "-" + rsl[0]
@@ -183,7 +183,7 @@ def pingpong(lstOut):
     lstOut[idx][6] = pong[2]
     lstOut[idx][7] = pong[3]
     if pong[0] == 0:
-      if lstOut[idx][9] == None:
+      if lstOut[idx][9] is None:
         lstOut[idx][9] = 0
 
   return lstOut


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Mausy5043:dhcpns?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:Mausy5043:dhcpns?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
